### PR TITLE
feat: add Docker setup for development

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+dist
+drizzle
+.git
+.gitignore
+.env
+.env.local
+*.log
+*.md
+!README.md
+Dockerfile
+docker-compose.yml
+.dockerignore

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+FROM oven/bun:1 AS base
+WORKDIR /app
+
+# Install dependencies
+FROM base AS deps
+COPY package.json bun.lockb* ./
+RUN bun install --frozen-lockfile
+
+# Development
+FROM base AS dev
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+CMD ["bun", "run", "dev"]
+
+# Production build
+FROM base AS prod
+COPY --from=deps /app/node_modules ./node_modules
+COPY . .
+
+ENV NODE_ENV=production
+EXPOSE 3000
+
+CMD ["bun", "run", "start"]

--- a/README.md
+++ b/README.md
@@ -11,6 +11,24 @@ Personal finance management API. Built for AI-first workflows.
 
 ## Quick Start
 
+### With Docker (recommended)
+
+```bash
+# Start API + PostgreSQL
+docker compose up
+
+# Run migrations (in another terminal)
+docker compose exec api bun run db:generate
+docker compose exec api bun run db:migrate
+
+# Optional: Drizzle Studio (DB GUI)
+docker compose --profile tools up studio
+```
+
+API available at `http://localhost:3000`
+
+### Without Docker
+
 ```bash
 # Install dependencies
 bun install

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,56 @@
+services:
+  api:
+    build:
+      context: .
+      target: dev
+    ports:
+      - "3000:3000"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - DATABASE_URL=postgresql://koin:koin@db:5432/koin
+      - PORT=3000
+    depends_on:
+      db:
+        condition: service_healthy
+    restart: unless-stopped
+
+  db:
+    image: postgres:16-alpine
+    ports:
+      - "5432:5432"
+    environment:
+      - POSTGRES_USER=koin
+      - POSTGRES_PASSWORD=koin
+      - POSTGRES_DB=koin
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U koin -d koin"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+    restart: unless-stopped
+
+  # Optional: Drizzle Studio for DB management
+  studio:
+    build:
+      context: .
+      target: dev
+    ports:
+      - "4983:4983"
+    volumes:
+      - .:/app
+      - /app/node_modules
+    environment:
+      - DATABASE_URL=postgresql://koin:koin@db:5432/koin
+    depends_on:
+      db:
+        condition: service_healthy
+    command: ["bun", "run", "db:studio"]
+    profiles:
+      - tools
+
+volumes:
+  postgres_data:


### PR DESCRIPTION
## Summary
Adds Docker configuration for easier local development.

## Changes
- `Dockerfile` with multi-stage build (dev + prod targets)
- `docker-compose.yml` with:
  - API service (hot reload via volume mount)
  - PostgreSQL 16 with health checks
  - Optional Drizzle Studio (via `--profile tools`)
- `.dockerignore` for clean builds
- Updated README with Docker instructions

## Usage
```bash
# Start everything
docker compose up

# Run migrations
docker compose exec api bun run db:generate
docker compose exec api bun run db:migrate
```