### PR TITLE
fix(docker): run bun directly for proper signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,4 @@ COPY . .
 ENV NODE_ENV=production
 EXPOSE 3000
 
-CMD ["bun", "run", "start"]
+CMD ["bun", "src/index.ts"]


### PR DESCRIPTION
## Problem

Running `bun run start` in the Dockerfile spawns a child process. When Docker sends SIGTERM during deployments, the signal goes to the parent `bun run` process instead of the actual app, causing:

```
error: script "start" was terminated by signal SIGTERM (Polite quit request)
```

## Solution

Run bun directly with `bun src/index.ts` instead of `bun run start`. This ensures:
- Proper signal propagation to the app
- Graceful shutdown handling
- No more SIGTERM errors during deployments

## Changes

- `Dockerfile`: Changed `CMD ["bun", "run", "start"]` to `CMD ["bun", "src/index.ts"]`