### PR TITLE
fix(web): add vite-env.d.ts for import.meta.env types

### DIFF
--- a/web/src/vite-env.d.ts
+++ b/web/src/vite-env.d.ts
@@ -1,0 +1,9 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_API_URL: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}


### PR DESCRIPTION
## Problem

TypeScript build fails with:
```
src/pages/Settings.tsx(58,24): error TS2339: Property 'env' does not exist on type 'ImportMeta'.
```

## Solution

Added `web/src/vite-env.d.ts` with Vite client type references so TypeScript recognizes `import.meta.env`.

## Tested

```
$ bun run build
✓ 172 modules transformed.
✓ built in 4.05s
```