### PR TITLE
fix(web): use VITE_API_URL for API calls, remove nginx proxy

### DIFF
--- a/web/nginx.conf
+++ b/web/nginx.conf
@@ -8,16 +8,6 @@ server {
         try_files $uri $uri/ /index.html;
     }
 
-    # Proxy API requests
-    location /api {
-        proxy_pass http://api:3000;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection 'upgrade';
-        proxy_set_header Host $host;
-        proxy_cache_bypass $http_upgrade;
-    }
-
     # Cache static assets
     location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {
         expires 1y;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-const API_BASE = "/api";
+const API_BASE = `${import.meta.env.VITE_API_URL || ""}/api`;
 
 export class ApiError extends Error {
   constructor(


### PR DESCRIPTION
## Problem

Frontend deployment fails with:
```
host not found in upstream "api" in /etc/nginx/conf.d/default.conf:13
```

The nginx config was trying to proxy `/api` to `http://api:3000`, but that hostname doesn't exist in Easypanel's network.

## Solution

- Use `VITE_API_URL` environment variable in `api.ts` for all API calls
- Remove the nginx proxy block (API calls are client-side via fetch)

This makes the frontend work as a standalone static site that calls the API directly.

## Deployment

Set `VITE_API_URL=https://koin.taufiqseptryana.com` (or your API URL) as a build arg in Easypanel.