### PR TITLE
feat(docker): auto-run migrations on startup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,10 @@ CMD ["bun", "run", "dev"]
 FROM base AS prod
 COPY --from=deps /app/node_modules ./node_modules
 COPY . .
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
 
 ENV NODE_ENV=production
 EXPOSE 3000
 
-CMD ["bun", "src/index.ts"]
+CMD ["./docker-entrypoint.sh"]

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+echo "Running database migrations..."
+bun run db:migrate
+
+echo "Starting server..."
+exec bun src/index.ts


### PR DESCRIPTION
## Problem

Database migrations weren't running on deployment.

## Solution

Added `docker-entrypoint.sh` that runs `bun run db:migrate` before starting the server.

## Changes

- Added `docker-entrypoint.sh` script
- Updated `Dockerfile` to use the entrypoint script

## Startup flow

1. Run `bun run db:migrate` (drizzle-kit migrate)
2. Start server with `bun src/index.ts`