### PR TITLE
fix(docker): include drizzle migrations in build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,5 @@
 node_modules
 dist
-drizzle
 .git
 .gitignore
 .env


### PR DESCRIPTION
## Problem

Migrations fail with:
```
error: Can't find meta/_journal.json file
```

The `drizzle/` folder was excluded in `.dockerignore`, so migration files weren't copied to the Docker image.

## Solution

Removed `drizzle` from `.dockerignore`.