### PR TITLE
fix: include SKILL.md in Docker image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -7,6 +7,7 @@ dist
 *.log
 *.md
 !README.md
+!SKILL.md
 Dockerfile
 docker-compose.yml
 .dockerignore


### PR DESCRIPTION
## Problem

The `/api/skill/download` endpoint was returning a 500 error:
```
ENOENT: no such file or directory, open '/app/SKILL.md'
```

## Cause

The `.dockerignore` file had `*.md` which excluded all markdown files from the Docker build context. While `README.md` had an exception, `SKILL.md` did not.

## Fix

Added `!SKILL.md` to the `.dockerignore` exceptions.

## Testing

After merging, rebuild and redeploy the Docker image. The skill endpoint should work correctly.