### PR TITLE
feat(web): use dynamic currency symbol from user settings

### DIFF
--- a/web/src/lib/currency.ts
+++ b/web/src/lib/currency.ts
@@ -1,0 +1,51 @@
+// Currency code to symbol mapping
+const CURRENCY_SYMBOLS: Record<string, string> = {
+  USD: "$",
+  EUR: "€",
+  GBP: "£",
+  JPY: "¥",
+  CNY: "¥",
+  INR: "₹",
+  CAD: "$",
+  AUD: "$",
+  CHF: "Fr",
+  KRW: "₩",
+  SGD: "$",
+  IDR: "Rp",
+  MYR: "RM",
+  THB: "฿",
+  VND: "₫",
+  PHP: "₱",
+  BRL: "R$",
+  MXN: "$",
+};
+
+/**
+ * Get currency symbol for a currency code
+ */
+export function getCurrencySymbol(currency: string): string {
+  return CURRENCY_SYMBOLS[currency] || currency;
+}
+
+/**
+ * Format amount with currency symbol
+ */
+export function formatCurrency(amount: number | string, currency: string): string {
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  const symbol = getCurrencySymbol(currency);
+  return `${symbol}${num.toFixed(2)}`;
+}
+
+/**
+ * Format amount with sign and currency symbol
+ */
+export function formatCurrencyWithSign(
+  amount: number | string,
+  currency: string,
+  type: "income" | "expense"
+): string {
+  const num = typeof amount === "string" ? parseFloat(amount) : amount;
+  const symbol = getCurrencySymbol(currency);
+  const sign = type === "income" ? "+" : "-";
+  return `${sign}${symbol}${num.toFixed(2)}`;
+}

--- a/web/src/pages/Dashboard.tsx
+++ b/web/src/pages/Dashboard.tsx
@@ -1,8 +1,13 @@
 import { useQuery } from "@tanstack/react-query";
 import { summary, transactions } from "../lib/api";
 import { Link } from "@tanstack/react-router";
+import { useAuth } from "../hooks/useAuth";
+import { formatCurrency, formatCurrencyWithSign } from "../lib/currency";
 
 export function DashboardPage() {
+  const { user } = useAuth();
+  const currency = user?.currency || "USD";
+
   const { data: summaryData, isLoading: summaryLoading } = useQuery({
     queryKey: ["summary"],
     queryFn: () => summary.get(),
@@ -27,18 +32,21 @@ export function DashboardPage() {
         <StatCard
           title="Income"
           value={stats?.income ?? 0}
+          currency={currency}
           isLoading={summaryLoading}
           color="green"
         />
         <StatCard
           title="Expenses"
           value={stats?.expenses ?? 0}
+          currency={currency}
           isLoading={summaryLoading}
           color="red"
         />
         <StatCard
           title="Balance"
           value={stats?.balance ?? 0}
+          currency={currency}
           isLoading={summaryLoading}
           color="blue"
         />
@@ -87,8 +95,7 @@ export function DashboardPage() {
                     tx.type === "income" ? "text-green-600" : "text-red-600"
                   }`}
                 >
-                  {tx.type === "income" ? "+" : "-"}$
-                  {parseFloat(tx.amount).toFixed(2)}
+                  {formatCurrencyWithSign(tx.amount, currency, tx.type)}
                 </span>
               </li>
             ))}
@@ -114,7 +121,7 @@ export function DashboardPage() {
                   {cat.categoryName || "Uncategorized"}
                 </span>
                 <span className="font-medium text-gray-900">
-                  ${parseFloat(cat.total).toFixed(2)}
+                  {formatCurrency(cat.total, currency)}
                 </span>
               </li>
             ))}
@@ -128,11 +135,13 @@ export function DashboardPage() {
 function StatCard({
   title,
   value,
+  currency,
   isLoading,
   color,
 }: {
   title: string;
   value: number;
+  currency: string;
   isLoading: boolean;
   color: "green" | "red" | "blue";
 }) {
@@ -149,7 +158,7 @@ function StatCard({
         <div className="mt-2 h-8 bg-gray-200 rounded animate-pulse" />
       ) : (
         <p className={`mt-2 text-3xl font-bold ${colorClasses[color]}`}>
-          ${value.toFixed(2)}
+          {formatCurrency(value, currency)}
         </p>
       )}
     </div>

--- a/web/src/pages/Transactions.tsx
+++ b/web/src/pages/Transactions.tsx
@@ -6,8 +6,12 @@ import {
   type Transaction,
   type CreateTransaction,
 } from "../lib/api";
+import { useAuth } from "../hooks/useAuth";
+import { formatCurrencyWithSign } from "../lib/currency";
 
 export function TransactionsPage() {
+  const { user } = useAuth();
+  const currency = user?.currency || "USD";
   const queryClient = useQueryClient();
   const [showForm, setShowForm] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
@@ -104,8 +108,7 @@ export function TransactionsPage() {
                       tx.type === "income" ? "text-green-600" : "text-red-600"
                     }`}
                   >
-                    {tx.type === "income" ? "+" : "-"}$
-                    {parseFloat(tx.amount).toFixed(2)}
+                    {formatCurrencyWithSign(tx.amount, currency, tx.type)}
                   </span>
                   <button
                     onClick={() => {


### PR DESCRIPTION
## Summary
Replaces hardcoded `$` symbols with the user's configured currency.

## Changes
- Added `web/src/lib/currency.ts` utility:
  - `getCurrencySymbol(currency)` — returns symbol for currency code
  - `formatCurrency(amount, currency)` — formats amount with symbol
  - `formatCurrencyWithSign(amount, currency, type)` — adds +/- prefix
- Updated **Dashboard** page:
  - Stats cards (Income, Expenses, Balance)
  - Recent transactions list
  - Spending by category
- Updated **Transactions** page:
  - Transaction amounts in list

## Supported Currencies
USD ($), EUR (€), GBP (£), JPY (¥), CNY (¥), INR (₹), CAD ($), AUD ($), CHF (Fr), KRW (₩), SGD ($), IDR (Rp), MYR (RM), THB (฿), VND (₫), PHP (₱), BRL (R$), MXN ($)

## Tests
All 91 tests pass (53 backend + 38 frontend)