### PR TITLE
feat(web): add thousand separators to currency formatting

### DIFF
--- a/web/src/lib/currency.ts
+++ b/web/src/lib/currency.ts
@@ -28,16 +28,26 @@ export function getCurrencySymbol(currency: string): string {
 }
 
 /**
- * Format amount with currency symbol
+ * Format number with thousand separators
+ */
+export function formatNumber(num: number, decimals: number = 2): string {
+  return num.toLocaleString("en-US", {
+    minimumFractionDigits: decimals,
+    maximumFractionDigits: decimals,
+  });
+}
+
+/**
+ * Format amount with currency symbol and thousand separators
  */
 export function formatCurrency(amount: number | string, currency: string): string {
   const num = typeof amount === "string" ? parseFloat(amount) : amount;
   const symbol = getCurrencySymbol(currency);
-  return `${symbol}${num.toFixed(2)}`;
+  return `${symbol}${formatNumber(num)}`;
 }
 
 /**
- * Format amount with sign and currency symbol
+ * Format amount with sign, currency symbol, and thousand separators
  */
 export function formatCurrencyWithSign(
   amount: number | string,
@@ -47,5 +57,5 @@ export function formatCurrencyWithSign(
   const num = typeof amount === "string" ? parseFloat(amount) : amount;
   const symbol = getCurrencySymbol(currency);
   const sign = type === "income" ? "+" : "-";
-  return `${sign}${symbol}${num.toFixed(2)}`;
+  return `${sign}${symbol}${formatNumber(num)}`;
 }

--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -36,8 +36,9 @@ describe("DashboardPage", () => {
     });
 
     // Check that stat values are rendered (use getAllBy since values may appear multiple times)
+    // Values are formatted with thousand separators: $3,000.00
     await waitFor(() => {
-      expect(screen.getAllByText(/\$3000\.00/).length).toBeGreaterThan(0);
+      expect(screen.getAllByText(/\$3,000\.00/).length).toBeGreaterThan(0);
       expect(screen.getAllByText(/\$25\.50/).length).toBeGreaterThan(0);
     });
   });


### PR DESCRIPTION
## Summary
Adds thousand separators to all currency amounts for better readability.

## Before
```
Rp37841920.00
```

## After
```
Rp37,841,920.00
```

## Changes
- Added `formatNumber()` utility using `toLocaleString`
- Applied to `formatCurrency()` and `formatCurrencyWithSign()`
- Updated test to match new format

All 38 frontend tests pass.