### PR TITLE
fix(ai): update confirm response format per #31 spec

### DIFF
--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -407,8 +407,11 @@ describe("AI Command Endpoint", () => {
       expect(status).toBe(200);
       expect(data.data.commandId).toBe(createData.data.commandId);
       expect(data.data.status).toBe("confirmed");
-      expect(data.data.updatedCount).toBe(2);
-      expect(data.data.message).toContain("2 transaction");
+      expect(data.data.result.updatedCount).toBe(2);
+      expect(data.data.result.transactions).toHaveLength(2);
+      expect(data.data.result.transactions[0]).toHaveProperty("id");
+      expect(data.data.result.transactions[0]).toHaveProperty("description");
+      expect(data.data.result.transactions[0]).toHaveProperty("category");
 
       // Verify transactions were updated
       const db = getTestDb();


### PR DESCRIPTION
## Summary
Updates the confirm endpoint response format to match issue #31 spec exactly.

## Changes
- Return transactions inside a `result` object instead of at the top level
- Include updated transaction details (id, description, category name)
- Remove `message` field from response (not in spec)

### Before
```json
{
  "data": {
    "commandId": "uuid",
    "status": "confirmed",
    "updatedCount": 2,
    "message": "Successfully updated 2 transaction(s)"
  }
}
```

### After
```json
{
  "data": {
    "commandId": "uuid",
    "status": "confirmed",
    "result": {
      "updatedCount": 2,
      "transactions": [
        { "id": "...", "description": "...", "category": "Food" }
      ]
    }
  }
}
```

## Testing
- All 152 tests pass
- Updated test expectations for new response format

Closes #31