### PR TITLE
fix(ai): return clear error when OpenRouter not configured

### DIFF
--- a/src/lib/openrouter.ts
+++ b/src/lib/openrouter.ts
@@ -46,6 +46,13 @@ export class OpenRouterAPIError extends Error {
   }
 }
 
+export class OpenRouterConfigError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "OpenRouterConfigError";
+  }
+}
+
 export class OpenRouterValidationError extends Error {
   constructor(message: string, public details?: unknown) {
     super(message);
@@ -287,7 +294,9 @@ export function createOpenRouterClient(): OpenRouterClient {
   const model = process.env.OPENROUTER_MODEL || "anthropic/claude-sonnet-4";
 
   if (!apiKey) {
-    throw new Error("OPENROUTER_API_KEY environment variable is required");
+    throw new OpenRouterConfigError(
+      "AI features are not configured. Please set OPENROUTER_API_KEY."
+    );
   }
 
   return new OpenRouterClient({ apiKey, model });

--- a/web/src/components/AIAssistant.tsx
+++ b/web/src/components/AIAssistant.tsx
@@ -62,8 +62,12 @@ export function AIAssistant({ isOpen, onClose }: AIAssistantProps) {
     },
     onError: (err: Error) => {
       if (err instanceof ApiError) {
-        const data = err.data as { error?: string };
-        setError(data.error || "Failed to interpret command");
+        const data = err.data as { error?: string; code?: string; message?: string };
+        if (data.code === "AI_NOT_CONFIGURED") {
+          setError(data.message || "AI features are not available. Please contact the administrator.");
+        } else {
+          setError(data.error || "Failed to interpret command");
+        }
       } else {
         setError(err.message || "Failed to interpret command");
       }


### PR DESCRIPTION
## Problem
When OPENROUTER_API_KEY is not set, the AI assistant shows a generic "Internal server error" which isn't helpful.

## Solution
- Add `OpenRouterConfigError` class for missing API key errors
- Backend returns 503 with `code: AI_NOT_CONFIGURED` and a clear message
- Frontend detects this code and shows: *"AI features are not available. Please contact the administrator."*

## Changes
- `src/lib/openrouter.ts` — New error class, updated createOpenRouterClient
- `src/routes/ai.ts` — Catch config error and return 503
- `web/src/components/AIAssistant.tsx` — Handle AI_NOT_CONFIGURED code

## Testing
- 152 backend tests pass
- 65 frontend tests pass