### PR TITLE
fix(ai): include changes in command response

### DIFF
--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -242,6 +242,12 @@ app.post("/command", async (c) => {
     // Generate preview records
     const records = generatePreviewRecords(matchingTransactions, interpretation.action.changes, categoryLookup);
 
+    // Build changes object with category name lookup
+    const changes: Record<string, unknown> = { ...interpretation.action.changes };
+    if (interpretation.action.changes.categoryId) {
+      changes.categoryName = categoryLookup.get(interpretation.action.changes.categoryId);
+    }
+
     // Store command in database
     const expiresAt = new Date(Date.now() + COMMAND_EXPIRY_MS);
     const [command] = await db
@@ -265,6 +271,7 @@ app.post("/command", async (c) => {
           matchCount: matchingTransactions.length,
           records,
         },
+        changes,
         expiresIn: COMMAND_EXPIRY_SECONDS,
       },
     }, 201);

--- a/web/src/components/AIAssistant.tsx
+++ b/web/src/components/AIAssistant.tsx
@@ -229,7 +229,7 @@ export function AIAssistant({ isOpen, onClose }: AIAssistantProps) {
                     <PreviewCard
                       key={record.id}
                       record={record}
-                      changes={preview.changes}
+                      changes={preview.changes || {}}
                       currency={currency}
                     />
                   ))}


### PR DESCRIPTION
## Problem
Frontend crashes with `Cannot read properties of undefined (reading 'categoryName')` when using AI command.

## Solution
- Backend now includes `changes` object with `categoryName` in the response
- Frontend handles missing `changes` gracefully with fallback to empty object

## Changes
- `src/routes/ai.ts` — Add `changes` to response with category name lookup
- `web/src/components/AIAssistant.tsx` — Handle `preview.changes || {}`