### PR TITLE
fix(ai): correct preview records format

### DIFF
--- a/src/routes/ai.ts
+++ b/src/routes/ai.ts
@@ -126,24 +126,15 @@ function generatePreviewRecords(
   changes: AIAction["changes"],
   categoryLookup: Map<string, string>
 ) {
-  return matchingTransactions.map(tx => {
-    const before = {
-      description: tx.description,
-      category: tx.categoryId ? categoryLookup.get(tx.categoryId) || null : null,
-      amount: tx.amount,
-    };
-
-    const after = { ...before };
-    if (changes.amount) after.amount = changes.amount;
-    if (changes.description !== undefined) after.description = changes.description;
-    if (changes.categoryId) after.category = categoryLookup.get(changes.categoryId) || changes.categoryId;
-
-    return {
-      id: tx.id,
-      before,
-      after,
-    };
-  });
+  return matchingTransactions.map(tx => ({
+    id: tx.id,
+    description: tx.description,
+    amount: tx.amount,
+    date: tx.date.toISOString(),
+    categoryId: tx.categoryId,
+    categoryName: tx.categoryId ? categoryLookup.get(tx.categoryId) || null : null,
+    type: tx.type as "income" | "expense" | "adjustment",
+  }));
 }
 
 // POST /api/ai/command - Create a new command (interpret & stage)

--- a/tests/ai.test.ts
+++ b/tests/ai.test.ts
@@ -137,12 +137,13 @@ describe("AI Command Endpoint", () => {
       // #30 spec: expiresIn (seconds) instead of expiresAt
       expect(data.data.expiresIn).toBe(300);
 
-      // Check preview record structure per #30
+      // Check preview record structure
       const record = data.data.preview.records[0];
       expect(record.id).toBeDefined();
-      expect(record.before).toBeDefined();
-      expect(record.after).toBeDefined();
-      expect(record.after.category).toBe("Food");
+      expect(record.description).toBeDefined();
+      expect(record.amount).toBeDefined();
+      expect(record.date).toBeDefined();
+      expect(record.type).toBeDefined();
     });
 
     it("should return 404 when no transactions match", async () => {
@@ -581,7 +582,7 @@ describe("AI Command Endpoint", () => {
       });
 
       expect(data.data.preview.matchCount).toBe(1);
-      expect(data.data.preview.records[0].before.amount).toBe("5.50");
+      expect(data.data.preview.records[0].amount).toBe("5.50");
     });
 
     it("should filter by transaction_type", async () => {
@@ -631,8 +632,8 @@ describe("AI Command Endpoint", () => {
       });
 
       expect(data.data.preview.matchCount).toBe(1);
-      expect(data.data.preview.records[0].before.category).toBe("Food");
-      expect(data.data.preview.records[0].after.category).toBe("Transport");
+      expect(data.data.preview.records[0].categoryName).toBe("Food");
+      expect(data.data.changes.categoryName).toBe("Transport");
     });
   });
 
@@ -648,7 +649,7 @@ describe("AI Command Endpoint", () => {
         prompt: "Change coffee to $10",
       });
 
-      expect(data.data.preview.records[0].after.amount).toBe("10.00");
+      expect(data.data.changes.amount).toBe("10.00");
     });
 
     it("should change description", async () => {
@@ -662,7 +663,7 @@ describe("AI Command Endpoint", () => {
         prompt: "Rename coffee to Morning coffee",
       });
 
-      expect(data.data.preview.records[0].after.description).toBe("Morning coffee");
+      expect(data.data.changes.description).toBe("Morning coffee");
     });
 
     it("should change category", async () => {
@@ -676,8 +677,8 @@ describe("AI Command Endpoint", () => {
         prompt: "Put Groceries in Food",
       });
 
-      expect(data.data.preview.records[0].before.category).toBeNull();
-      expect(data.data.preview.records[0].after.category).toBe("Food");
+      expect(data.data.preview.records[0].categoryName).toBeNull();
+      expect(data.data.changes.categoryName).toBe("Food");
     });
   });
 });


### PR DESCRIPTION
## Problem
AI preview was showing transactions with Rp0.00 and 'No description' because the backend returned `{ id, before, after }` but frontend expected `{ id, description, amount, date, categoryId, categoryName, type }`.

## Solution
Fixed `generatePreviewRecords` to return the correct flat structure matching frontend expectations.

### Before
```json
{ "id": "...", "before": { ... }, "after": { ... } }
```

### After
```json
{ 
  "id": "...", 
  "description": "Fliptech payment",
  "amount": "3300000",
  "date": "2026-02-15T...",
  "categoryId": null,
  "categoryName": null,
  "type": "expense"
}
```

## Testing
- All 152 backend tests pass
- Updated test assertions to match new format