### PR TITLE
feat(web): add DateRangePicker component

### DIFF
--- a/web/src/components/DateRangePicker.test.tsx
+++ b/web/src/components/DateRangePicker.test.tsx
@@ -1,0 +1,181 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { DateRangePicker, getDefaultDateRange, type DateRange } from "./DateRangePicker";
+
+describe("DateRangePicker", () => {
+  const mockOnChange = vi.fn();
+  
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders with default display", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "", to: "" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    expect(screen.getByText("All time")).toBeInTheDocument();
+  });
+
+  it("opens dropdown when clicked", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "", to: "" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("All time"));
+    
+    expect(screen.getByText("This month")).toBeInTheDocument();
+    expect(screen.getByText("Last month")).toBeInTheDocument();
+    expect(screen.getByText("Last 3 months")).toBeInTheDocument();
+    expect(screen.getByText("Year to date")).toBeInTheDocument();
+  });
+
+  it("calls onChange with preset value", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "", to: "" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("All time"));
+    fireEvent.click(screen.getByText("Last month"));
+
+    expect(mockOnChange).toHaveBeenCalledTimes(1);
+    const call = mockOnChange.mock.calls[0][0] as DateRange;
+    expect(call.from).toBeDefined();
+    expect(call.to).toBeDefined();
+  });
+
+  it("shows custom range inputs", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "", to: "" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("All time"));
+    
+    expect(screen.getByText("Custom range")).toBeInTheDocument();
+    expect(screen.getByLabelText("From")).toBeInTheDocument();
+    expect(screen.getByLabelText("To")).toBeInTheDocument();
+    expect(screen.getByText("Apply")).toBeInTheDocument();
+  });
+
+  it("applies custom date range", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "", to: "" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("All time"));
+    
+    const fromInput = screen.getByLabelText("From");
+    const toInput = screen.getByLabelText("To");
+    
+    fireEvent.change(fromInput, { target: { value: "2026-01-01" } });
+    fireEvent.change(toInput, { target: { value: "2026-01-31" } });
+    
+    fireEvent.click(screen.getByText("Apply"));
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      from: "2026-01-01",
+      to: "2026-01-31",
+    });
+  });
+
+  it("disables Apply button when dates are missing", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "", to: "" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    fireEvent.click(screen.getByText("All time"));
+    
+    const applyButton = screen.getByText("Apply");
+    expect(applyButton).toBeDisabled();
+  });
+
+  it("displays custom date range in trigger", () => {
+    render(
+      <DateRangePicker
+        value={{ from: "2026-01-15", to: "2026-02-15" }}
+        onChange={mockOnChange}
+      />
+    );
+
+    // Should show formatted date range
+    expect(screen.getByText(/Jan 15, 2026/)).toBeInTheDocument();
+  });
+
+  it("highlights active preset", () => {
+    const today = new Date();
+    const startOfMonth = new Date(today.getFullYear(), today.getMonth(), 1);
+    
+    render(
+      <DateRangePicker
+        value={{ 
+          from: startOfMonth.toISOString().split("T")[0], 
+          to: today.toISOString().split("T")[0] 
+        }}
+        onChange={mockOnChange}
+      />
+    );
+
+    // Open dropdown
+    fireEvent.click(screen.getByRole("button"));
+    
+    // "This month" button in the dropdown should have active styling
+    const buttons = screen.getAllByText("This month");
+    // The second one is in the dropdown (first is in the trigger display)
+    const thisMonthButton = buttons.length > 1 ? buttons[1] : buttons[0];
+    expect(thisMonthButton).toHaveClass("bg-emerald-100");
+  });
+
+  it("closes dropdown when clicking outside", () => {
+    render(
+      <div>
+        <DateRangePicker
+          value={{ from: "", to: "" }}
+          onChange={mockOnChange}
+        />
+        <div data-testid="outside">Outside</div>
+      </div>
+    );
+
+    // Open dropdown
+    fireEvent.click(screen.getByText("All time"));
+    expect(screen.getByText("Custom range")).toBeInTheDocument();
+
+    // Click outside
+    fireEvent.mouseDown(screen.getByTestId("outside"));
+    
+    // Dropdown should be closed
+    expect(screen.queryByText("Custom range")).not.toBeInTheDocument();
+  });
+});
+
+describe("getDefaultDateRange", () => {
+  it("returns this month range", () => {
+    const range = getDefaultDateRange();
+    
+    expect(range.from).toBeDefined();
+    expect(range.to).toBeDefined();
+    expect(range.from).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(range.to).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    
+    // "from" should be the 1st of the month
+    expect(range.from.endsWith("-01")).toBe(true);
+  });
+});

--- a/web/src/components/DateRangePicker.tsx
+++ b/web/src/components/DateRangePicker.tsx
@@ -1,0 +1,208 @@
+import { useState, useRef, useEffect } from "react";
+
+export interface DateRange {
+  from: string; // YYYY-MM-DD
+  to: string;   // YYYY-MM-DD
+}
+
+interface Preset {
+  label: string;
+  getValue: () => DateRange;
+}
+
+const getPresets = (): Preset[] => {
+  const today = new Date();
+  const formatDate = (d: Date) => d.toISOString().split("T")[0];
+
+  return [
+    {
+      label: "This month",
+      getValue: () => {
+        const start = new Date(today.getFullYear(), today.getMonth(), 1);
+        return { from: formatDate(start), to: formatDate(today) };
+      },
+    },
+    {
+      label: "Last month",
+      getValue: () => {
+        const start = new Date(today.getFullYear(), today.getMonth() - 1, 1);
+        const end = new Date(today.getFullYear(), today.getMonth(), 0);
+        return { from: formatDate(start), to: formatDate(end) };
+      },
+    },
+    {
+      label: "Last 3 months",
+      getValue: () => {
+        const start = new Date(today.getFullYear(), today.getMonth() - 2, 1);
+        return { from: formatDate(start), to: formatDate(today) };
+      },
+    },
+    {
+      label: "Year to date",
+      getValue: () => {
+        const start = new Date(today.getFullYear(), 0, 1);
+        return { from: formatDate(start), to: formatDate(today) };
+      },
+    },
+    {
+      label: "All time",
+      getValue: () => ({ from: "", to: "" }),
+    },
+  ];
+};
+
+interface DateRangePickerProps {
+  value: DateRange;
+  onChange: (range: DateRange) => void;
+}
+
+export function DateRangePicker({ value, onChange }: DateRangePickerProps) {
+  const [isOpen, setIsOpen] = useState(false);
+  const [customFrom, setCustomFrom] = useState(value.from);
+  const [customTo, setCustomTo] = useState(value.to);
+  const dropdownRef = useRef<HTMLDivElement>(null);
+
+  const presets = getPresets();
+
+  // Close dropdown when clicking outside
+  useEffect(() => {
+    const handleClickOutside = (event: MouseEvent) => {
+      if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+        setIsOpen(false);
+      }
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  // Sync custom inputs when value changes externally
+  useEffect(() => {
+    setCustomFrom(value.from);
+    setCustomTo(value.to);
+  }, [value.from, value.to]);
+
+  const getDisplayLabel = (): string => {
+    if (!value.from && !value.to) return "All time";
+    
+    // Check if it matches a preset
+    for (const preset of presets) {
+      const presetValue = preset.getValue();
+      if (presetValue.from === value.from && presetValue.to === value.to) {
+        return preset.label;
+      }
+    }
+
+    // Format custom range
+    const formatDisplay = (d: string) => {
+      if (!d) return "...";
+      const date = new Date(d);
+      return date.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    };
+
+    return `${formatDisplay(value.from)} - ${formatDisplay(value.to)}`;
+  };
+
+  const handlePresetClick = (preset: Preset) => {
+    const newValue = preset.getValue();
+    onChange(newValue);
+    setCustomFrom(newValue.from);
+    setCustomTo(newValue.to);
+    setIsOpen(false);
+  };
+
+  const handleCustomApply = () => {
+    onChange({ from: customFrom, to: customTo });
+    setIsOpen(false);
+  };
+
+  return (
+    <div className="relative" ref={dropdownRef}>
+      {/* Trigger button */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="flex items-center gap-2 px-3 py-2 text-sm bg-white border border-gray-300 rounded-lg hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-emerald-500"
+      >
+        <svg className="w-4 h-4 text-gray-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z" />
+        </svg>
+        <span className="text-gray-700">{getDisplayLabel()}</span>
+        <svg className={`w-4 h-4 text-gray-400 transition-transform ${isOpen ? "rotate-180" : ""}`} fill="none" stroke="currentColor" viewBox="0 0 24 24">
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      {/* Dropdown */}
+      {isOpen && (
+        <div className="absolute right-0 mt-2 w-72 bg-white border border-gray-200 rounded-lg shadow-lg z-50">
+          {/* Presets */}
+          <div className="p-2 border-b border-gray-100">
+            <div className="grid grid-cols-2 gap-1">
+              {presets.map((preset) => {
+                const presetValue = preset.getValue();
+                const isActive = presetValue.from === value.from && presetValue.to === value.to;
+                return (
+                  <button
+                    key={preset.label}
+                    onClick={() => handlePresetClick(preset)}
+                    className={`px-3 py-1.5 text-sm rounded-md text-left transition-colors ${
+                      isActive
+                        ? "bg-emerald-100 text-emerald-700 font-medium"
+                        : "text-gray-700 hover:bg-gray-100"
+                    }`}
+                  >
+                    {preset.label}
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+
+          {/* Custom range */}
+          <div className="p-3">
+            <p className="text-xs font-medium text-gray-500 mb-2">Custom range</p>
+            <div className="flex gap-2 mb-2">
+              <div className="flex-1">
+                <label htmlFor="date-from" className="block text-xs text-gray-500 mb-1">From</label>
+                <input
+                  id="date-from"
+                  type="date"
+                  value={customFrom}
+                  onChange={(e) => setCustomFrom(e.target.value)}
+                  className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                />
+              </div>
+              <div className="flex-1">
+                <label htmlFor="date-to" className="block text-xs text-gray-500 mb-1">To</label>
+                <input
+                  id="date-to"
+                  type="date"
+                  value={customTo}
+                  onChange={(e) => setCustomTo(e.target.value)}
+                  className="w-full px-2 py-1.5 text-sm border border-gray-300 rounded-md focus:outline-none focus:ring-1 focus:ring-emerald-500"
+                />
+              </div>
+            </div>
+            <button
+              onClick={handleCustomApply}
+              disabled={!customFrom || !customTo}
+              className="w-full px-3 py-1.5 text-sm bg-emerald-600 text-white rounded-md hover:bg-emerald-700 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              Apply
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Helper to get default "This month" range
+export function getDefaultDateRange(): DateRange {
+  const today = new Date();
+  const start = new Date(today.getFullYear(), today.getMonth(), 1);
+  return {
+    from: start.toISOString().split("T")[0],
+    to: today.toISOString().split("T")[0],
+  };
+}


### PR DESCRIPTION
## Summary
Reusable date range picker component with preset options for filtering dashboard data.

## Features
- **Preset buttons:** This month, Last month, Last 3 months, Year to date, All time
- **Custom date range:** From/To date inputs with Apply button
- **Dropdown:** Closes on outside click, shows selected range in trigger
- **Accessibility:** Proper label associations, keyboard accessible

## Usage
```tsx
import { DateRangePicker, getDefaultDateRange } from './components/DateRangePicker';

const [dateRange, setDateRange] = useState(getDefaultDateRange());

<DateRangePicker
  value={dateRange}
  onChange={setDateRange}
/>
```

## Testing
- 10 new tests for DateRangePicker
- All 75 frontend tests pass

Closes #50