### PR TITLE
feat(web): add BalanceTrendChart component

### DIFF
--- a/web/src/components/BalanceTrendChart.test.tsx
+++ b/web/src/components/BalanceTrendChart.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { BalanceTrendChart } from "./BalanceTrendChart";
+
+// Mock recharts ResponsiveContainer
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 400, height: 400 }}>{children}</div>
+    ),
+  };
+});
+
+const mockData = [
+  { date: "2026-01-01", income: 1000, expenses: 500, balance: 500 },
+  { date: "2026-01-02", income: 200, expenses: 100, balance: 600 },
+  { date: "2026-01-03", income: 300, expenses: 200, balance: 700 },
+];
+
+describe("BalanceTrendChart", () => {
+  it("renders loading state", () => {
+    render(
+      <BalanceTrendChart
+        data={[]}
+        currency="USD"
+        isLoading={true}
+      />
+    );
+
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("renders empty state when no data", () => {
+    render(
+      <BalanceTrendChart
+        data={[]}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText("No trend data available")).toBeInTheDocument();
+  });
+
+  it("renders chart with data", () => {
+    const { container } = render(
+      <BalanceTrendChart
+        data={mockData}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    // Chart should render
+    expect(container.querySelector(".recharts-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders with negative balances", () => {
+    const negativeData = [
+      { date: "2026-01-01", income: 100, expenses: 500, balance: -400 },
+      { date: "2026-01-02", income: 50, expenses: 100, balance: -450 },
+    ];
+
+    const { container } = render(
+      <BalanceTrendChart
+        data={negativeData}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(container.querySelector(".recharts-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders with single data point", () => {
+    const singlePoint = [
+      { date: "2026-01-01", income: 1000, expenses: 500, balance: 500 },
+    ];
+
+    const { container } = render(
+      <BalanceTrendChart
+        data={singlePoint}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(container.querySelector(".recharts-wrapper")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/BalanceTrendChart.tsx
+++ b/web/src/components/BalanceTrendChart.tsx
@@ -1,0 +1,141 @@
+import {
+  AreaChart,
+  Area,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  ResponsiveContainer,
+} from "recharts";
+import { formatCurrency } from "../lib/currency";
+
+interface TrendPoint {
+  date: string;
+  income: number;
+  expenses: number;
+  balance: number;
+}
+
+interface BalanceTrendChartProps {
+  data: TrendPoint[];
+  currency: string;
+  isLoading?: boolean;
+}
+
+export function BalanceTrendChart({ data, currency, isLoading }: BalanceTrendChartProps) {
+  if (isLoading) {
+    return (
+      <div className="h-64 flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-gray-200 border-t-emerald-500 rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="h-64 flex items-center justify-center text-gray-500">
+        No trend data available
+      </div>
+    );
+  }
+
+  // Format date for display
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+
+  // Custom tooltip
+  const CustomTooltip = ({ 
+    active, 
+    payload, 
+    label 
+  }: { 
+    active?: boolean; 
+    payload?: Array<{ value: number }>; 
+    label?: string;
+  }) => {
+    if (!active || !payload || !payload.length || !label) return null;
+
+    const balance = payload[0].value;
+    const date = new Date(label);
+    const formattedDate = date.toLocaleDateString("en-US", { 
+      weekday: "short",
+      month: "short", 
+      day: "numeric",
+      year: "numeric",
+    });
+
+    return (
+      <div className="bg-white px-3 py-2 shadow-lg rounded-lg border border-gray-200">
+        <p className="text-sm text-gray-500 mb-1">{formattedDate}</p>
+        <p className={`font-semibold ${balance >= 0 ? "text-emerald-600" : "text-red-600"}`}>
+          {formatCurrency(balance, currency)}
+        </p>
+      </div>
+    );
+  };
+
+  // Determine min/max for better Y-axis display
+  const balances = data.map(d => d.balance);
+  const minBalance = Math.min(...balances);
+  const maxBalance = Math.max(...balances);
+  const padding = (maxBalance - minBalance) * 0.1 || 100;
+  const yMin = Math.floor((minBalance - padding) / 100) * 100;
+  const yMax = Math.ceil((maxBalance + padding) / 100) * 100;
+
+  // Determine if balance is generally positive or negative for gradient color
+  const avgBalance = balances.reduce((a, b) => a + b, 0) / balances.length;
+  const gradientColor = avgBalance >= 0 ? "#10B981" : "#EF4444"; // emerald or red
+
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <AreaChart
+          data={data}
+          margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+        >
+          <defs>
+            <linearGradient id="balanceGradient" x1="0" y1="0" x2="0" y2="1">
+              <stop offset="5%" stopColor={gradientColor} stopOpacity={0.3} />
+              <stop offset="95%" stopColor={gradientColor} stopOpacity={0} />
+            </linearGradient>
+          </defs>
+          <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatDate}
+            tick={{ fontSize: 12, fill: "#6B7280" }}
+            axisLine={{ stroke: "#E5E7EB" }}
+            tickLine={false}
+            interval="preserveStartEnd"
+          />
+          <YAxis
+            domain={[yMin, yMax]}
+            tickFormatter={(value) => {
+              if (Math.abs(value) >= 1000000) {
+                return `${(value / 1000000).toFixed(1)}M`;
+              }
+              if (Math.abs(value) >= 1000) {
+                return `${(value / 1000).toFixed(0)}K`;
+              }
+              return value.toString();
+            }}
+            tick={{ fontSize: 12, fill: "#6B7280" }}
+            axisLine={false}
+            tickLine={false}
+            width={50}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Area
+            type="monotone"
+            dataKey="balance"
+            stroke={gradientColor}
+            strokeWidth={2}
+            fill="url(#balanceGradient)"
+          />
+        </AreaChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Line/area chart showing balance over time on the dashboard.

## Features
- **Area chart** with balance line and gradient fill
- **Dynamic colors:** Green gradient for positive balance, red for negative
- **Custom tooltip** with full date and formatted currency
- **Smart Y-axis:** Formats large numbers as K/M (1.5K, 2.3M)
- **Responsive** sizing
- **Loading/empty states**

## Data Source
Uses `GET /api/summary/trend` endpoint from #49

## Testing
- 5 new tests for BalanceTrendChart
- All 85 frontend tests pass

Closes #52