### PR TITLE
feat(web): add IncomeExpenseChart component

### DIFF
--- a/web/src/components/IncomeExpenseChart.test.tsx
+++ b/web/src/components/IncomeExpenseChart.test.tsx
@@ -1,0 +1,110 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { IncomeExpenseChart } from "./IncomeExpenseChart";
+
+// Mock recharts ResponsiveContainer
+vi.mock("recharts", async () => {
+  const actual = await vi.importActual("recharts");
+  return {
+    ...actual,
+    ResponsiveContainer: ({ children }: { children: React.ReactNode }) => (
+      <div style={{ width: 400, height: 400 }}>{children}</div>
+    ),
+  };
+});
+
+const mockMonthlyData = [
+  { date: "2026-01-01", income: 5000, expenses: 3000, balance: 2000 },
+  { date: "2026-02-01", income: 4500, expenses: 3500, balance: 3000 },
+  { date: "2026-03-01", income: 6000, expenses: 4000, balance: 5000 },
+];
+
+const mockDailyData = [
+  { date: "2026-01-15", income: 100, expenses: 50, balance: 50 },
+  { date: "2026-01-16", income: 200, expenses: 80, balance: 170 },
+  { date: "2026-01-17", income: 150, expenses: 100, balance: 220 },
+];
+
+describe("IncomeExpenseChart", () => {
+  it("renders loading state", () => {
+    render(
+      <IncomeExpenseChart
+        data={[]}
+        currency="USD"
+        isLoading={true}
+      />
+    );
+
+    const spinner = document.querySelector(".animate-spin");
+    expect(spinner).toBeInTheDocument();
+  });
+
+  it("renders empty state when no data", () => {
+    render(
+      <IncomeExpenseChart
+        data={[]}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(screen.getByText("No data available")).toBeInTheDocument();
+  });
+
+  it("renders chart with monthly data", () => {
+    const { container } = render(
+      <IncomeExpenseChart
+        data={mockMonthlyData}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(container.querySelector(".recharts-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders chart with daily data", () => {
+    const { container } = render(
+      <IncomeExpenseChart
+        data={mockDailyData}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(container.querySelector(".recharts-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders with single data point", () => {
+    const singlePoint = [
+      { date: "2026-01-01", income: 1000, expenses: 500, balance: 500 },
+    ];
+
+    const { container } = render(
+      <IncomeExpenseChart
+        data={singlePoint}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(container.querySelector(".recharts-wrapper")).toBeInTheDocument();
+  });
+
+  it("renders with zero values", () => {
+    const zeroData = [
+      { date: "2026-01-01", income: 0, expenses: 0, balance: 0 },
+      { date: "2026-02-01", income: 0, expenses: 0, balance: 0 },
+    ];
+
+    const { container } = render(
+      <IncomeExpenseChart
+        data={zeroData}
+        currency="USD"
+        isLoading={false}
+      />
+    );
+
+    expect(container.querySelector(".recharts-wrapper")).toBeInTheDocument();
+  });
+});

--- a/web/src/components/IncomeExpenseChart.tsx
+++ b/web/src/components/IncomeExpenseChart.tsx
@@ -1,0 +1,168 @@
+import {
+  BarChart,
+  Bar,
+  XAxis,
+  YAxis,
+  CartesianGrid,
+  Tooltip,
+  Legend,
+  ResponsiveContainer,
+} from "recharts";
+import { formatCurrency } from "../lib/currency";
+
+interface TrendPoint {
+  date: string;
+  income: number;
+  expenses: number;
+  balance: number;
+}
+
+interface IncomeExpenseChartProps {
+  data: TrendPoint[];
+  currency: string;
+  isLoading?: boolean;
+}
+
+export function IncomeExpenseChart({ data, currency, isLoading }: IncomeExpenseChartProps) {
+  if (isLoading) {
+    return (
+      <div className="h-64 flex items-center justify-center">
+        <div className="w-8 h-8 border-2 border-gray-200 border-t-emerald-500 rounded-full animate-spin" />
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) {
+    return (
+      <div className="h-64 flex items-center justify-center text-gray-500">
+        No data available
+      </div>
+    );
+  }
+
+  // Format date for display (show month for monthly, day for daily)
+  const formatDate = (dateStr: string) => {
+    const date = new Date(dateStr);
+    // Check if data spans multiple months (monthly view) or days (daily view)
+    if (data.length > 1) {
+      const firstDate = new Date(data[0].date);
+      const lastDate = new Date(data[data.length - 1].date);
+      const daysDiff = (lastDate.getTime() - firstDate.getTime()) / (1000 * 60 * 60 * 24);
+      
+      if (daysDiff > 60) {
+        // Monthly view
+        return date.toLocaleDateString("en-US", { month: "short" });
+      }
+    }
+    // Daily/weekly view
+    return date.toLocaleDateString("en-US", { month: "short", day: "numeric" });
+  };
+
+  // Custom tooltip
+  const CustomTooltip = ({ 
+    active, 
+    payload, 
+    label 
+  }: { 
+    active?: boolean; 
+    payload?: Array<{ dataKey: string; value: number; color: string }>; 
+    label?: string;
+  }) => {
+    if (!active || !payload || !payload.length || !label) return null;
+
+    const date = new Date(label);
+    const formattedDate = date.toLocaleDateString("en-US", { 
+      month: "long", 
+      year: "numeric",
+    });
+
+    return (
+      <div className="bg-white px-3 py-2 shadow-lg rounded-lg border border-gray-200">
+        <p className="text-sm text-gray-500 mb-2">{formattedDate}</p>
+        {payload.map((entry, index) => (
+          <div key={index} className="flex items-center justify-between gap-4">
+            <div className="flex items-center gap-2">
+              <div 
+                className="w-3 h-3 rounded-sm" 
+                style={{ backgroundColor: entry.color }} 
+              />
+              <span className="text-sm text-gray-600 capitalize">{entry.dataKey}</span>
+            </div>
+            <span className="text-sm font-medium">
+              {formatCurrency(entry.value, currency)}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  // Custom legend
+  const CustomLegend = ({ payload }: { payload?: Array<{ value: string; color: string }> }) => {
+    if (!payload) return null;
+
+    return (
+      <div className="flex justify-center gap-6 mt-2">
+        {payload.map((entry, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <div 
+              className="w-3 h-3 rounded-sm" 
+              style={{ backgroundColor: entry.color }} 
+            />
+            <span className="text-sm text-gray-600 capitalize">{entry.value}</span>
+          </div>
+        ))}
+      </div>
+    );
+  };
+
+  return (
+    <div className="h-64">
+      <ResponsiveContainer width="100%" height="100%">
+        <BarChart
+          data={data}
+          margin={{ top: 10, right: 10, left: 0, bottom: 0 }}
+          barCategoryGap="20%"
+        >
+          <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" vertical={false} />
+          <XAxis
+            dataKey="date"
+            tickFormatter={formatDate}
+            tick={{ fontSize: 12, fill: "#6B7280" }}
+            axisLine={{ stroke: "#E5E7EB" }}
+            tickLine={false}
+          />
+          <YAxis
+            tickFormatter={(value) => {
+              if (Math.abs(value) >= 1000000) {
+                return `${(value / 1000000).toFixed(1)}M`;
+              }
+              if (Math.abs(value) >= 1000) {
+                return `${(value / 1000).toFixed(0)}K`;
+              }
+              return value.toString();
+            }}
+            tick={{ fontSize: 12, fill: "#6B7280" }}
+            axisLine={false}
+            tickLine={false}
+            width={50}
+          />
+          <Tooltip content={<CustomTooltip />} />
+          <Legend content={<CustomLegend />} />
+          <Bar 
+            dataKey="income" 
+            fill="#10B981" 
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+          />
+          <Bar 
+            dataKey="expenses" 
+            fill="#EF4444" 
+            radius={[4, 4, 0, 0]}
+            maxBarSize={40}
+          />
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Bar chart comparing income and expenses by period.

## Features
- **Grouped bars:** Income (green) and Expenses (red) side by side
- **Smart date formatting:** Shows month for monthly data, day for daily
- **Rounded corners** on bars
- **Custom tooltip** with month/year and formatted amounts
- **Legend** showing income/expenses colors
- **Loading/empty states**

## Data Source
Uses `GET /api/summary/trend?period=monthly` endpoint from #49

## Testing
- 6 new tests for IncomeExpenseChart
- All 91 frontend tests pass

Closes #53