### PR TITLE
feat(web): integrate date range picker into dashboard

### DIFF
--- a/web/src/pages/Dashboard.test.tsx
+++ b/web/src/pages/Dashboard.test.tsx
@@ -109,8 +109,8 @@ describe("DashboardPage", () => {
       expect(screen.getByText(/click to adjust/i)).toBeInTheDocument();
     });
 
-    // Click on the Balance card
-    const balanceCard = screen.getByRole("button");
+    // Click on the Balance card (has "Click to adjust" text)
+    const balanceCard = screen.getByText(/click to adjust/i).closest('[role="button"]') as HTMLElement;
     await user.click(balanceCard);
 
     // Modal should appear
@@ -130,7 +130,8 @@ describe("DashboardPage", () => {
     });
 
     // Click on the Balance card
-    await user.click(screen.getByRole("button"));
+    const balanceCard = screen.getByText(/click to adjust/i).closest('[role="button"]') as HTMLElement;
+    await user.click(balanceCard);
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("0.00")).toBeInTheDocument();
@@ -155,7 +156,8 @@ describe("DashboardPage", () => {
       expect(screen.getByText(/click to adjust/i)).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button"));
+    const balanceCard = screen.getByText(/click to adjust/i).closest('[role="button"]') as HTMLElement;
+    await user.click(balanceCard);
 
     await waitFor(() => {
       expect(screen.getByText(/adjust balance/i)).toBeInTheDocument();
@@ -176,7 +178,8 @@ describe("DashboardPage", () => {
       expect(screen.getByText(/click to adjust/i)).toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button"));
+    const balanceCard = screen.getByText(/click to adjust/i).closest('[role="button"]') as HTMLElement;
+    await user.click(balanceCard);
 
     await waitFor(() => {
       expect(screen.getByPlaceholderText("0.00")).toBeInTheDocument();


### PR DESCRIPTION
## Summary
Wire up the date range picker to filter all dashboard data.

## Features
- **Date picker in header** — Select any date range
- **Dynamic filtering** — Summary stats filtered by selected range
- **Smart comparison** — Previous period calculated based on range duration
- **Comparison label** — Shows "vs previous period" / "vs previous quarter"

## How It Works
1. User selects a date range (e.g., "Last 3 months")
2. Dashboard fetches summary for that range
3. Previous period is calculated (same duration before the range)
4. Stat cards show % change vs previous period

## Testing
- Updated 4 dashboard tests to use specific selectors
- All 91 frontend tests pass

Closes #55