### PR TITLE
fix: redirect to login on 401 instead of showing error

### DIFF
--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,19 +1,46 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
-import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { QueryClient, QueryClientProvider, QueryCache, MutationCache } from "@tanstack/react-query";
 import { RouterProvider, createRouter } from "@tanstack/react-router";
 import { routeTree } from "./routes";
 import { AuthProvider } from "./hooks/useAuth";
+import { ApiError } from "./lib/api";
 import "./index.css";
 
+// Module-level reference for the queryClient (set after creation)
+let queryClientRef: QueryClient | null = null;
+
+// Global handler for 401 errors - clears auth state to trigger redirect
+const handle401 = (error: unknown): void => {
+  if (error instanceof ApiError && error.status === 401 && queryClientRef) {
+    // Clear auth state - this will trigger redirect to login
+    queryClientRef.setQueryData(["auth", "me"], null);
+  }
+};
+
 const queryClient = new QueryClient({
+  queryCache: new QueryCache({
+    onError: handle401,
+  }),
+  mutationCache: new MutationCache({
+    onError: handle401,
+  }),
   defaultOptions: {
     queries: {
       staleTime: 1000 * 60, // 1 minute
-      retry: 1,
+      retry: (failureCount, error) => {
+        // Don't retry on 401
+        if (error instanceof ApiError && error.status === 401) {
+          return false;
+        }
+        return failureCount < 1;
+      },
     },
   },
 });
+
+// Set the reference after creation
+queryClientRef = queryClient;
 
 const router = createRouter({
   routeTree,

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -2,7 +2,6 @@ import {
   createRootRoute,
   createRoute,
   Outlet,
-  redirect,
   Navigate,
   useLocation,
 } from "@tanstack/react-router";
@@ -74,7 +73,7 @@ const protectedLayout = createRoute({
     }
 
     if (!isAuthenticated) {
-      throw redirect({ to: "/login" });
+      return <Navigate to="/login" />;
     }
 
     return (


### PR DESCRIPTION
## Problem
When a user's session expires or they get a 401 Unauthorized response on protected pages (dashboard, etc.), the app shows an error state instead of redirecting to login.

## Solution

### 1. Fixed protectedLayout redirect
Changed from `throw redirect({ to: '/login' })` to `<Navigate to='/login' />`. The `throw redirect` pattern doesn't work correctly inside component functions in TanStack Router.

### 2. Added global 401 error handling
Added `QueryCache` and `MutationCache` with `onError` handlers that:
- Detect 401 ApiError responses
- Clear the auth query data (sets user to null)
- This triggers a re-render in protectedLayout, which then redirects to login

### 3. Skip retry on 401
Modified the default retry function to not retry on 401 errors — there's no point retrying an unauthorized request.

## Changes
- `main.tsx`: Added QueryCache/MutationCache with 401 handling, custom retry logic
- `routes/index.tsx`: Changed to use `<Navigate />` component instead of `throw redirect()`