### PR TITLE
fix: add database connection pool limits

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -11,7 +11,11 @@ export function getDb(): PostgresJsDatabase<typeof schema> {
     if (!connectionString) {
       throw new Error("DATABASE_URL environment variable is required");
     }
-    client = postgres(connectionString);
+    client = postgres(connectionString, {
+      max: 20,
+      idle_timeout: 10,
+      connect_timeout: 30,
+    });
     _db = drizzle(client, { schema });
   }
   return _db;


### PR DESCRIPTION
Closes #125

This PR adds connection pool configuration to the postgres client:

- **max**: 20 connections (limits concurrent connections)
- **idle_timeout**: 10 seconds (close idle connections)
- **connect_timeout**: 30 seconds (timeout for connection attempts)

The postgres client was previously created without any pool limits, which could lead to connection exhaustion under high load.