### PR TITLE
fix: token refresh race and request timeouts

### DIFF
--- a/web/src/components/ErrorBoundary.tsx
+++ b/web/src/components/ErrorBoundary.tsx
@@ -1,0 +1,61 @@
+import { Component, type ReactNode } from "react";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error: Error | null;
+}
+
+export class ErrorBoundary extends Component<Props, State> {
+  constructor(props: Props) {
+    super(props);
+    this.state = { hasError: false, error: null };
+  }
+
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  override componentDidCatch(error: Error, errorInfo: React.ErrorInfo) {
+    console.error("ErrorBoundary caught error:", error, errorInfo);
+  }
+
+  override render() {
+    if (this.state.hasError) {
+      if (this.props.fallback) {
+        return this.props.fallback;
+      }
+
+      return (
+        <div className="flex min-h-screen items-center justify-center p-4">
+          <div className="w-full max-w-md rounded-lg bg-white p-6 shadow-lg">
+            <h2 className="mb-4 text-xl font-semibold text-red-600">
+              Something went wrong
+            </h2>
+            <p className="mb-4 text-gray-600">
+              An error occurred while loading this page. Please try refreshing
+              or contact support if the problem persists.
+            </p>
+            {this.state.error && (
+              <pre className="mb-4 max-h-32 overflow-auto rounded bg-gray-100 p-3 text-sm text-gray-800">
+                {this.state.error.message}
+              </pre>
+            )}
+            <button
+              onClick={() => window.location.reload()}
+              className="w-full rounded-md bg-blue-600 px-4 py-2 text-white hover:bg-blue-700"
+            >
+              Refresh Page
+            </button>
+          </div>
+        </div>
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 const API_BASE = `${import.meta.env.VITE_API_URL || ""}/api`;
+const DEFAULT_TIMEOUT = 10000; // 10 seconds
 
 export class ApiError extends Error {
   constructor(
@@ -10,13 +11,12 @@ export class ApiError extends Error {
   }
 }
 
-// Token refresh state to prevent concurrent refresh attempts
-let isRefreshing = false;
+// Singleton promise pattern for token refresh to prevent race conditions
 let refreshPromise: Promise<boolean> | null = null;
 
 async function attemptTokenRefresh(): Promise<boolean> {
   try {
-    const response = await fetch(`${API_BASE}/auth/refresh`, {
+    const response = await fetchWithTimeout(`${API_BASE}/auth/refresh`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       credentials: "include",
@@ -28,29 +28,56 @@ async function attemptTokenRefresh(): Promise<boolean> {
 }
 
 async function refreshToken(): Promise<boolean> {
-  if (isRefreshing && refreshPromise) {
-    return refreshPromise;
+  // Singleton promise pattern: if a refresh is already in progress, wait for it
+  if (!refreshPromise) {
+    refreshPromise = attemptTokenRefresh().finally(() => {
+      refreshPromise = null;
+    });
   }
-  isRefreshing = true;
-  refreshPromise = attemptTokenRefresh().finally(() => {
-    isRefreshing = false;
-    refreshPromise = null;
-  });
   return refreshPromise;
+}
+
+// Fetch with timeout using AbortController
+async function fetchWithTimeout(
+  url: string,
+  options: RequestInit & { timeout?: number } = {}
+): Promise<Response> {
+  const { timeout = DEFAULT_TIMEOUT, ...fetchOptions } = options;
+  
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+  
+  try {
+    const response = await fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal,
+    });
+    return response;
+  } catch (error) {
+    if (error instanceof Error && error.name === "AbortError") {
+      throw new Error(`Request timeout after ${timeout}ms`);
+    }
+    throw error;
+  } finally {
+    clearTimeout(timeoutId);
+  }
 }
 
 async function request<T>(
   path: string,
-  options: RequestInit = {},
+  options: RequestInit & { timeout?: number } = {},
   _isRetry = false
 ): Promise<T> {
-  const response = await fetch(`${API_BASE}${path}`, {
-    ...options,
+  const { timeout, ...requestOptions } = options;
+  
+  const response = await fetchWithTimeout(`${API_BASE}${path}`, {
+    ...requestOptions,
     headers: {
       "Content-Type": "application/json",
-      ...options.headers,
+      ...requestOptions.headers,
     },
     credentials: "include", // Include cookies for auth
+    timeout,
   });
 
   // If we get a 401 and this isn't already a retry, attempt token refresh

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -9,6 +9,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useAuth } from "../hooks/useAuth";
 import { auth } from "../lib/api";
 import { Layout } from "../components/Layout";
+import { ErrorBoundary } from "../components/ErrorBoundary";
 import { LoginPage } from "../pages/Login";
 import { RegisterPage } from "../pages/Register";
 import { SetupPage } from "../pages/Setup";
@@ -80,9 +81,11 @@ const protectedLayout = createRoute({
     }
 
     return (
-      <Layout>
-        <Outlet />
-      </Layout>
+      <ErrorBoundary>
+        <Layout>
+          <Outlet />
+        </Layout>
+      </ErrorBoundary>
     );
   },
 });


### PR DESCRIPTION
Fixes #128

## Changes

1. **Token refresh race condition fix**: Replaced the module-level  flag with a proper singleton promise pattern. All concurrent requests now await the same refresh promise instead of potentially triggering multiple refresh attempts.

2. **Request timeouts**: Added  helper using  with a 10-second default timeout. All API requests now support an optional timeout parameter and will throw a clear timeout error if the request takes too long.

3. **Error boundary at route level**: Created  component that catches React errors and displays a user-friendly fallback UI with a refresh button. The protected routes are now wrapped with this boundary to prevent the entire app from crashing on errors.