### PR TITLE
fix: floating-point precision in financial calculations (closes #124)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "koin",
       "dependencies": {
         "@hono/zod-validator": "^0.4.0",
+        "decimal.js": "^10.6.0",
         "drizzle-orm": "^0.38.0",
         "hono": "^4.0.0",
         "hono-rate-limiter": "^0.5.3",
@@ -85,6 +86,8 @@
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hono/zod-validator": "^0.4.0",
+    "decimal.js": "^10.6.0",
     "drizzle-orm": "^0.38.0",
     "hono": "^4.0.0",
     "hono-rate-limiter": "^0.5.3",

--- a/src/services/debt-payment.ts
+++ b/src/services/debt-payment.ts
@@ -2,6 +2,7 @@ import { eq, and } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type * as schema from "../db/schema";
 import { debtAccounts, debts, debtPayments, debtPaymentAllocations } from "../db/schema";
+import { Decimal } from "decimal.js";
 
 export type DebtPaymentService = ReturnType<typeof createDebtPaymentService>;
 
@@ -56,12 +57,13 @@ export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) 
         .orderBy(debts.createdAt);
 
       if (activeDebts.length > 0) {
-        let remaining = Number(amount);
+        let remaining = new Decimal(amount);
 
         for (const debt of activeDebts) {
-          if (remaining <= 0) break;
-          const allocAmount = Math.min(remaining, Number(debt.monthlyAmount));
-          remaining -= allocAmount;
+          if (remaining.lte(0)) break;
+          const debtMonthly = new Decimal(debt.monthlyAmount);
+          const allocAmount = remaining.lt(debtMonthly) ? remaining : debtMonthly;
+          remaining = remaining.minus(allocAmount);
 
           await tx.insert(debtPaymentAllocations).values({
             paymentId: payment.id,
@@ -71,7 +73,7 @@ export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) 
         }
 
         // Excess goes to first debt
-        if (remaining > 0) {
+        if (remaining.gt(0)) {
           const firstAllocation = await tx
             .select()
             .from(debtPaymentAllocations)
@@ -83,7 +85,7 @@ export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) 
             );
 
           if (firstAllocation.length > 0) {
-            const newAmount = Number(firstAllocation[0].amount) + remaining;
+            const newAmount = new Decimal(firstAllocation[0].amount).plus(remaining);
             await tx
               .update(debtPaymentAllocations)
               .set({ amount: newAmount.toFixed(2) })


### PR DESCRIPTION
## Summary

Fixes floating-point precision errors in financial calculations by replacing JavaScript Number with decimal.js for precise decimal arithmetic.

## Changes

- Added decimal.js dependency for precise decimal arithmetic
- Updated src/services/debt-payment.ts to use Decimal for all monetary calculations:
  - Payment allocation calculations
  - Excess payment distribution
  - Amount comparisons and subtractions

## Testing

- All 364 existing tests pass
- TypeScript type checking passes
- The fix ensures accurate financial calculations without floating-point errors

Closes #124