### PR TITLE
fix: add pagination to transaction list endpoint

### DIFF
--- a/src/routes/transactions.ts
+++ b/src/routes/transactions.ts
@@ -11,7 +11,7 @@ const app = new Hono();
 // List transactions (scoped to user)
 app.get("/", async (c) => {
   const userId = c.get("userId");
-  const { startDate, endDate, type, categoryId } = c.req.query();
+  const { startDate, endDate, type, categoryId, limit: limitParam, offset: offsetParam } = c.req.query();
   
   const conditions = [eq(transactions.userId, userId)];
   
@@ -20,13 +20,33 @@ app.get("/", async (c) => {
   if (type) conditions.push(eq(transactions.type, type as "income" | "expense" | "adjustment"));
   if (categoryId) conditions.push(eq(transactions.categoryId, categoryId));
   
+  // Parse and validate pagination parameters
+  const limit = Math.min(parseInt(limitParam || "100", 10), 500);
+  const offset = parseInt(offsetParam || "0", 10);
+  
+  // Get paginated results
   const result = await db
     .select()
     .from(transactions)
     .where(and(...conditions))
-    .orderBy(desc(transactions.date));
+    .orderBy(desc(transactions.date))
+    .limit(limit)
+    .offset(offset);
     
-  return c.json({ data: result });
+  // Get total count for pagination UI
+  const [{ count }] = await db
+    .select({ count: sql`count(*)` })
+    .from(transactions)
+    .where(and(...conditions));
+    
+  return c.json({ 
+    data: result, 
+    pagination: {
+      limit,
+      offset,
+      total: Number(count)
+    }
+  });
 });
 
 // Get single transaction (scoped to user)

--- a/tests/transactions.test.ts
+++ b/tests/transactions.test.ts
@@ -444,6 +444,86 @@ describe("Transactions API", () => {
       expect(status).toBe(200);
       expect(data.data).toHaveLength(0);
     });
+
+    // Pagination tests
+    it("should return default limit of 100 when no limit specified", async () => {
+      // Create 5 transactions
+      for (let i = 0; i < 5; i++) {
+        await api.post("/api/transactions", { type: "expense", amount: "10.00", description: `Tx ${i}` });
+      }
+
+      const { status, data } = await api.get("/api/transactions");
+
+      expect(status).toBe(200);
+      expect(data.data).toHaveLength(5);
+      expect(data.pagination).toBeDefined();
+      expect(data.pagination.limit).toBe(100);
+      expect(data.pagination.offset).toBe(0);
+      expect(data.pagination.total).toBe(5);
+    });
+
+    it("should respect custom limit parameter", async () => {
+      // Create 10 transactions
+      for (let i = 0; i < 10; i++) {
+        await api.post("/api/transactions", { type: "expense", amount: "10.00", description: `Tx ${i}` });
+      }
+
+      const { status, data } = await api.get("/api/transactions?limit=5");
+
+      expect(status).toBe(200);
+      expect(data.data).toHaveLength(5);
+      expect(data.pagination.limit).toBe(5);
+      expect(data.pagination.total).toBe(10);
+    });
+
+    it("should cap limit at maximum of 500", async () => {
+      // Request limit of 1000, should be capped to 500
+      const { status, data } = await api.get("/api/transactions?limit=1000");
+
+      expect(status).toBe(200);
+      expect(data.pagination.limit).toBe(500);
+    });
+
+    it("should respect offset parameter", async () => {
+      // Create 5 transactions
+      for (let i = 0; i < 5; i++) {
+        await api.post("/api/transactions", { type: "expense", amount: "10.00", description: `Tx ${i}` });
+      }
+
+      const { status, data } = await api.get("/api/transactions?limit=2&offset=2");
+
+      expect(status).toBe(200);
+      expect(data.data).toHaveLength(2);
+      expect(data.pagination.limit).toBe(2);
+      expect(data.pagination.offset).toBe(2);
+      expect(data.pagination.total).toBe(5);
+    });
+
+    it("should handle offset beyond total count", async () => {
+      await api.post("/api/transactions", { type: "expense", amount: "10.00" });
+
+      const { status, data } = await api.get("/api/transactions?offset=100");
+
+      expect(status).toBe(200);
+      expect(data.data).toHaveLength(0);
+      expect(data.pagination.offset).toBe(100);
+      expect(data.pagination.total).toBe(1);
+    });
+
+    it("should work with filters and pagination together", async () => {
+      // Create mixed transactions
+      await api.post("/api/transactions", { type: "expense", amount: "10.00", description: "Expense 1" });
+      await api.post("/api/transactions", { type: "expense", amount: "20.00", description: "Expense 2" });
+      await api.post("/api/transactions", { type: "income", amount: "100.00", description: "Income 1" });
+      await api.post("/api/transactions", { type: "income", amount: "200.00", description: "Income 2" });
+
+      const { status, data } = await api.get("/api/transactions?type=expense&limit=1&offset=1");
+
+      expect(status).toBe(200);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0].type).toBe("expense");
+      expect(data.pagination.total).toBe(2); // Only 2 expense transactions
+    });
   });
 
   describe("GET /api/transactions/:id", () => {


### PR DESCRIPTION
Fixes #121. Prevents DoS vulnerability by adding pagination limits (default 100, max 500) to the unbounded transaction query.