### PR TITLE
fix: use decimal.js for financial precision

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "koin",
       "dependencies": {
         "@hono/zod-validator": "^0.4.0",
+        "decimal.js": "^10.6.0",
         "drizzle-orm": "^0.38.0",
         "hono": "^4.0.0",
         "hono-rate-limiter": "^0.5.3",
@@ -85,6 +86,8 @@
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "decimal.js": ["decimal.js@10.6.0", "", {}, "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg=="],
 
     "drizzle-kit": ["drizzle-kit@0.30.6", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0", "gel": "^2.0.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-U4wWit0fyZuGuP7iNmRleQyK2V8wCuv57vf5l3MnG4z4fzNTjY/U13M8owyQ5RavqvqxBifWORaR3wIUzlN64g=="],
 

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "@hono/zod-validator": "^0.4.0",
+    "decimal.js": "^10.6.0",
     "drizzle-orm": "^0.38.0",
     "hono": "^4.0.0",
     "hono-rate-limiter": "^0.5.3",

--- a/src/services/debt-payment.ts
+++ b/src/services/debt-payment.ts
@@ -2,6 +2,7 @@ import { eq, and } from "drizzle-orm";
 import type { PostgresJsDatabase } from "drizzle-orm/postgres-js";
 import type * as schema from "../db/schema";
 import { debtAccounts, debts, debtPayments, debtPaymentAllocations } from "../db/schema";
+import Decimal from "decimal.js";
 
 export type DebtPaymentService = ReturnType<typeof createDebtPaymentService>;
 
@@ -56,12 +57,12 @@ export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) 
         .orderBy(debts.createdAt);
 
       if (activeDebts.length > 0) {
-        let remaining = Number(amount);
+        let remaining = new Decimal(amount);
 
         for (const debt of activeDebts) {
-          if (remaining <= 0) break;
-          const allocAmount = Math.min(remaining, Number(debt.monthlyAmount));
-          remaining -= allocAmount;
+          if (remaining.lte(0)) break;
+          const allocAmount = Decimal.min(remaining, new Decimal(debt.monthlyAmount));
+          remaining = remaining.minus(allocAmount);
 
           await tx.insert(debtPaymentAllocations).values({
             paymentId: payment.id,
@@ -71,7 +72,7 @@ export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) 
         }
 
         // Excess goes to first debt
-        if (remaining > 0) {
+        if (remaining.gt(0)) {
           const firstAllocation = await tx
             .select()
             .from(debtPaymentAllocations)
@@ -83,7 +84,7 @@ export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) 
             );
 
           if (firstAllocation.length > 0) {
-            const newAmount = Number(firstAllocation[0].amount) + remaining;
+            const newAmount = new Decimal(firstAllocation[0].amount).plus(remaining);
             await tx
               .update(debtPaymentAllocations)
               .set({ amount: newAmount.toFixed(2) })

--- a/tests/financial-precision.test.ts
+++ b/tests/financial-precision.test.ts
@@ -1,0 +1,198 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
+import { setupTestDb, teardownTestDb, cleanupTables } from "./setup";
+import { createApi, createTestUser } from "./helpers";
+import Decimal from "decimal.js";
+
+describe("Financial Precision Tests", () => {
+  let api: ReturnType<typeof createApi>;
+  let userId: string;
+
+  beforeAll(async () => {
+    await setupTestDb();
+  });
+
+  afterAll(async () => {
+    await teardownTestDb();
+  });
+
+  beforeEach(async () => {
+    await cleanupTables();
+    const { token, response } = await createTestUser();
+    userId = response.data?.data?.user?.id;
+    api = createApi(token);
+  });
+
+  describe("Decimal.js precision", () => {
+    it("should correctly add 0.1 + 0.2 = 0.3 (floating-point precision test)", () => {
+      // JavaScript Number: 0.1 + 0.2 = 0.30000000000000004
+      // Decimal.js: 0.1 + 0.2 = 0.3
+      const a = new Decimal("0.1");
+      const b = new Decimal("0.2");
+      const result = a.plus(b);
+
+      expect(result.toString()).toBe("0.3");
+      expect(result.eq("0.3")).toBe(true);
+    });
+
+    it("should handle precise subtraction", () => {
+      const amount = new Decimal("100.00");
+      const deduction = new Decimal("0.1");
+      const result = amount.minus(deduction);
+
+      expect(result.toString()).toBe("99.9");
+    });
+
+    it("should correctly compare decimal values", () => {
+      const a = new Decimal("0.3");
+      const b = new Decimal("0.1").plus("0.2");
+
+      expect(a.eq(b)).toBe(true);
+      expect(a.gt("0.2")).toBe(true);
+      expect(a.lt("0.4")).toBe(true);
+    });
+
+    it("should handle Decimal.min correctly", () => {
+      const a = new Decimal("100.50");
+      const b = new Decimal("50.25");
+      const min = Decimal.min(a, b);
+
+      expect(min.toString()).toBe("50.25");
+    });
+  });
+
+  describe("Auto-payment with precise amounts", () => {
+    it("should allocate payments with precise decimal amounts", async () => {
+      const cat = await api.post("/api/categories", { name: "CC Bills" });
+      const categoryId = cat.data.data.id;
+
+      const acc = await api.post("/api/debt-accounts", {
+        name: "Test CC",
+        type: "credit_card",
+        billingDay: 20,
+        categoryId,
+      });
+      const accountId = acc.data.data.id;
+
+      // Create debt with precise monthly amount
+      await api.post(`/api/debt-accounts/${accountId}/debts`, {
+        name: "Test Debt",
+        type: "installment",
+        totalAmount: "10000",
+        monthlyAmount: "100.33", // Precise decimal
+      });
+
+      // Create payment transaction
+      await api.post("/api/transactions", {
+        type: "expense",
+        amount: "100.33",
+        categoryId,
+      });
+
+      const { data } = await api.get(`/api/debt-accounts/${accountId}/payments`);
+      expect(data.data).toHaveLength(1);
+      expect(data.data[0].totalAmount).toBe("100.33");
+      expect(data.data[0].allocations).toHaveLength(1);
+      expect(data.data[0].allocations[0].amount).toBe("100.33");
+    });
+
+    it("should correctly split excess payment without precision errors", async () => {
+      const cat = await api.post("/api/categories", { name: "CC Bills" });
+      const categoryId = cat.data.data.id;
+
+      const acc = await api.post("/api/debt-accounts", {
+        name: "Test CC",
+        type: "credit_card",
+        billingDay: 20,
+        categoryId,
+      });
+      const accountId = acc.data.data.id;
+
+      // Create two debts with precise amounts that could cause precision issues
+      await api.post(`/api/debt-accounts/${accountId}/debts`, {
+        name: "Debt A",
+        type: "installment",
+        totalAmount: "10000",
+        monthlyAmount: "33.33",
+      });
+      await api.post(`/api/debt-accounts/${accountId}/debts`, {
+        name: "Debt B",
+        type: "installment",
+        totalAmount: "5000",
+        monthlyAmount: "16.67",
+      });
+
+      // Pay total monthly (33.33 + 16.67 = 50.00)
+      await api.post("/api/transactions", {
+        type: "expense",
+        amount: "50.00",
+        categoryId,
+      });
+
+      const { data } = await api.get(`/api/debt-accounts/${accountId}/payments`);
+      expect(data.data).toHaveLength(1);
+
+      const allocations = data.data[0].allocations;
+      expect(allocations).toHaveLength(2);
+
+      // Verify exact amounts without floating-point errors
+      const totalAllocated = allocations.reduce(
+        (sum: number, a: any) => new Decimal(sum).plus(a.amount).toNumber(),
+        0
+      );
+      expect(new Decimal(totalAllocated).toFixed(2)).toBe("50.00");
+    });
+
+    it("should handle excess allocation with precise decimals", async () => {
+      const cat = await api.post("/api/categories", { name: "CC Bills" });
+      const categoryId = cat.data.data.id;
+
+      const acc = await api.post("/api/debt-accounts", {
+        name: "Test CC",
+        type: "credit_card",
+        billingDay: 20,
+        categoryId,
+      });
+      const accountId = acc.data.data.id;
+
+      await api.post(`/api/debt-accounts/${accountId}/debts`, {
+        name: "Debt A",
+        type: "installment",
+        totalAmount: "10000",
+        monthlyAmount: "33.33",
+      });
+      await api.post(`/api/debt-accounts/${accountId}/debts`, {
+        name: "Debt B",
+        type: "installment",
+        totalAmount: "5000",
+        monthlyAmount: "16.67",
+      });
+
+      // Pay with excess: 50.00 monthly + 10.00 excess = 60.00
+      await api.post("/api/transactions", {
+        type: "expense",
+        amount: "60.00",
+        categoryId,
+      });
+
+      const { data } = await api.get(`/api/debt-accounts/${accountId}/payments`);
+      expect(data.data).toHaveLength(1);
+
+      const allocations = data.data[0].allocations;
+      expect(allocations).toHaveLength(2);
+
+      // Debt A should get: 33.33 monthly + 10.00 excess = 43.33
+      // Debt B should get: 16.67 monthly
+      // Find by amount - Debt A has excess allocation
+      const debtAAlloc = allocations.find((a: any) => a.amount === "43.33");
+      expect(debtAAlloc).toBeDefined();
+
+      // Debt B should have 16.67
+      const debtBAlloc = allocations.find((a: any) => a.amount === "16.67");
+      expect(debtBAlloc).toBeDefined();
+
+      // Total should be exactly 60.00
+      const total = new Decimal(debtAAlloc.amount).plus(debtBAlloc.amount);
+      expect(total.toString()).toBe("60");
+    });
+  });
+});


### PR DESCRIPTION
Fixes #124. Replaces floating-point arithmetic with decimal.js to prevent precision errors in financial calculations.