### PR TITLE
fix(web): redirect authenticated users from login

### DIFF
--- a/web/src/routes/index.test.tsx
+++ b/web/src/routes/index.test.tsx
@@ -1,0 +1,60 @@
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { createMemoryHistory, createRouter, RouterProvider } from "@tanstack/react-router";
+import { render, screen, waitFor } from "@testing-library/react";
+import { http, HttpResponse } from "msw";
+import { describe, expect, it } from "vitest";
+import { AuthProvider } from "../hooks/useAuth";
+import { PrivacyProvider } from "../hooks/usePrivacy";
+import { server } from "../test/mocks/server";
+import { setAuthState } from "../test/mocks/handlers";
+import { routeTree } from ".";
+
+function renderApp(initialRoute: string) {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+      mutations: { retry: false },
+    },
+  });
+
+  const router = createRouter({
+    routeTree,
+    history: createMemoryHistory({ initialEntries: [initialRoute] }),
+    context: { queryClient },
+  });
+
+  render(
+    <QueryClientProvider client={queryClient}>
+      <AuthProvider>
+        <PrivacyProvider>
+          <RouterProvider router={router} />
+        </PrivacyProvider>
+      </AuthProvider>
+    </QueryClientProvider>
+  );
+
+  return { router };
+}
+
+describe("auth routes", () => {
+  it("redirects authenticated users away from login", async () => {
+    setAuthState(true);
+    server.use(
+      http.get("/api/auth/setup-status", () =>
+        HttpResponse.json({ data: { needsSetup: false } })
+      ),
+      http.get("/api/summary/trend", () =>
+        HttpResponse.json({
+          data: { period: "daily", from: "2026-05-01", to: "2026-05-10", points: [] },
+        })
+      )
+    );
+
+    const { router } = renderApp("/login");
+
+    await waitFor(() => {
+      expect(router.state.location.pathname).toBe("/");
+    });
+    expect(screen.queryByText(/welcome back/i)).not.toBeInTheDocument();
+  });
+});

--- a/web/src/routes/index.tsx
+++ b/web/src/routes/index.tsx
@@ -58,7 +58,23 @@ const rootRoute = createRootRoute({
 const authLayout = createRoute({
   getParentRoute: () => rootRoute,
   id: "auth",
-  component: () => <Outlet />,
+  component: () => {
+    const { isAuthenticated, isLoading } = useAuth();
+
+    if (isLoading) {
+      return (
+        <div className="flex h-screen items-center justify-center">
+          <div className="text-lg text-gray-500">Loading...</div>
+        </div>
+      );
+    }
+
+    if (isAuthenticated) {
+      return <Navigate to="/" />;
+    }
+
+    return <Outlet />;
+  },
 });
 
 // Protected layout (requires auth)


### PR DESCRIPTION
## Summary
- Redirect authenticated users away from auth routes (`/login`, `/register`) to the dashboard
- Prevent successful login sessions from appearing stuck on the login page
- Add route coverage for the authenticated-login redirect

## Test plan
- `bun run tsc --noEmit`
- `cd web && bun run test`
- `cd web && bun run build`
- `docker compose -f docker-compose.test.yml up --build --abort-on-container-exit --exit-code-from test`
- `docker build -t koin-backend .`
- `docker build -t koin-frontend ./web`

Note: direct host backend test with local Postgres failed because the local `test` DB credentials did not match; Docker Compose backend test passed with CI-equivalent Postgres.
