### PR TITLE
Fix atomic debt allocation increments

### DIFF
--- a/src/services/debt-payment.ts
+++ b/src/services/debt-payment.ts
@@ -6,6 +6,25 @@ import { Decimal } from "decimal.js";
 
 export type DebtPaymentService = ReturnType<typeof createDebtPaymentService>;
 
+type DbTransaction = Parameters<Parameters<PostgresJsDatabase<typeof schema>["transaction"]>[0]>[0];
+
+export async function incrementDebtPaymentAllocationAmount(
+  tx: DbTransaction,
+  allocationId: string,
+  amount: Decimal.Value
+) {
+  const increment = new Decimal(amount);
+
+  if (increment.lte(0)) return;
+
+  await tx
+    .update(debtPaymentAllocations)
+    .set({
+      amount: sql`${debtPaymentAllocations.amount} + ${increment.toFixed(2)}`,
+    })
+    .where(eq(debtPaymentAllocations.id, allocationId));
+}
+
 export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) {
   /**
    * Auto-detect and create a debt payment when a transaction matches a debt account's category.
@@ -85,12 +104,7 @@ export function createDebtPaymentService(db: PostgresJsDatabase<typeof schema>) 
             );
 
           if (firstAllocation.length > 0) {
-            const currentAmount = new Decimal(firstAllocation[0].amount);
-            const newAmount = currentAmount.plus(remaining);
-            await tx
-              .update(debtPaymentAllocations)
-              .set({ amount: newAmount.toFixed(2) })
-              .where(eq(debtPaymentAllocations.id, firstAllocation[0].id));
+            await incrementDebtPaymentAllocationAmount(tx, firstAllocation[0].id, remaining);
           }
         }
       }

--- a/tests/debt-tracker.test.ts
+++ b/tests/debt-tracker.test.ts
@@ -1,6 +1,9 @@
 import { describe, it, expect, beforeAll, afterAll, beforeEach } from "bun:test";
-import { setupTestDb, teardownTestDb, cleanupTables } from "./setup";
+import { setupTestDb, teardownTestDb, cleanupTables, getTestDb } from "./setup";
 import { createApi, createTestUser, createTestUserDirect } from "./helpers";
+import { debtPaymentAllocations, debtPayments } from "../src/db/schema";
+import { incrementDebtPaymentAllocationAmount } from "../src/services/debt-payment";
+import { eq } from "drizzle-orm";
 
 describe("Debt Tracker API", () => {
   let api: ReturnType<typeof createApi>;
@@ -1052,6 +1055,61 @@ describe("Debt Tracker API", () => {
       const secondAlloc = allocations.find((a: any) => a.debtId === debtBId);
       expect(firstAlloc.amount).toBe("1000000.00");
       expect(secondAlloc.amount).toBe("500000.00");
+    });
+
+    it("should atomically increment allocation amount under concurrent updates", async () => {
+      const db = getTestDb();
+
+      const acc = await api.post("/api/debt-accounts", {
+        name: "Concurrent CC",
+        type: "credit_card",
+        billingDay: 20,
+      });
+      const accountId = acc.data.data.id;
+
+      const debt = await api.post(`/api/debt-accounts/${accountId}/debts`, {
+        name: "Concurrent Debt",
+        type: "installment",
+        totalAmount: "10000000",
+        monthlyAmount: "1000000",
+      });
+      const debtId = debt.data.data.id;
+
+      const [payment] = await db
+        .insert(debtPayments)
+        .values({
+          accountId,
+          userId,
+          totalAmount: "0.00",
+          paidAt: new Date(),
+        })
+        .returning();
+
+      const [allocation] = await db
+        .insert(debtPaymentAllocations)
+        .values({
+          paymentId: payment.id,
+          debtId,
+          amount: "0.00",
+        })
+        .returning();
+
+      const increments = Array.from({ length: 25 }, () => "10.00");
+
+      await Promise.all(
+        increments.map((increment) =>
+          db.transaction((tx) =>
+            incrementDebtPaymentAllocationAmount(tx, allocation.id, increment)
+          )
+        )
+      );
+
+      const [updatedAllocation] = await db
+        .select()
+        .from(debtPaymentAllocations)
+        .where(eq(debtPaymentAllocations.id, allocation.id));
+
+      expect(updatedAllocation.amount).toBe("250.00");
     });
   });
 


### PR DESCRIPTION
## Summary
- Replace debt payment allocation read-modify-write with an atomic SQL increment
- Reuse the atomic increment in excess payment allocation updates
- Add a concurrent update regression test that verifies increments are not lost

Fixes #126

## Tests
- bun run tsc --noEmit
- bun run test:docker (378 passed)
- cd web && bun install && bun run test (114 passed)
- docker build -t koin-backend .
- docker build -t koin-frontend ./web

Note: direct local `bun test tests/` was attempted but the existing localhost PostgreSQL on port 5432 rejected the CI test credentials; the Docker test workflow was run successfully against its isolated test database.